### PR TITLE
Use explicit return types in WebAPI

### DIFF
--- a/Standards.fs
+++ b/Standards.fs
@@ -83,3 +83,9 @@ module Usage =
         |> List.map (fun f -> f * 4) // Avoid Multiple maps
         |> Array.ofList // When changing between list types, use the new type module to visually indicate this
 
+(*
+    Use explicit return types in WebAPI
+*)
+[<Route("some-data"); HttpGet>]
+member __.GetSomeData([<FromUri>] request : SomeDataRequest) : Threading.Tasks.Task<SomeDataResponse> = 
+    async.Return (SomeDataResponse.Zero()) |> Async.StartAsTask


### PR DESCRIPTION
To stop WebAPI responses from changing accidental due to implicit typing.
